### PR TITLE
Skip build ios in postinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ It is mandatory that you added:
 
     cordova plugin add https://github.com/voxeet/voxeet-cordova-conferencekit
 
+    By default the postinstall options will try to build the ios package. To skip the postinstall you can set env variable `VOXEET_SKIP_IOS_BUILD` to true. `export VOXEET_SKIP_IOS_BUILD=true` 
+
 ### iOS
 
 - after `cordova platform add ios` in the project root folder
@@ -19,29 +21,10 @@ It is mandatory that you added:
 
 To enable push notification, follow https://github.com/voxeet/voxeet-ios-conferencekit#project-setup
 
+
 ### Android
 
-- after `cordova platform add android` in the project root folder
-- edit the `platforms/android/app/build.gradle` with:
-
-```
-android {
-    defaultConfig {
-        // Enabling multidex support.
-        multiDexEnabled true
-    }
-    dexOptions {
-        jumboMode true
-        incremental true
-        javaMaxHeapSize "4g"
-    }
-}
-```
-
-- as well as the dependencies block, put in the top dependency position:
-```
-compile 'com.android.support:multidex:1.0.3'
-```
+No steps are required
 
 ### Notification
 

--- a/build_ios_frameworks.sh
+++ b/build_ios_frameworks.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-cd ./src/ios
-
-carthage update --platform ios
+if [ "$VOXEET_SKIP_IOS_BUILD" = "true" ]; then 
+    echo "Skipping ios build"
+    exit
+else
+    cd ./src/ios
+    carthage update --platform ios
+fi

--- a/package.json
+++ b/package.json
@@ -27,17 +27,11 @@
   "scripts": {
     "test": "npm run eslint",
     "eslint": "node node_modules/eslint/bin/eslint www && node node_modules/eslint/bin/eslint src && node node_modules/eslint/bin/eslint tests",
-    "build:ios": "bash build_ios_frameworks.sh"
+    "buildios": "bash build_ios_frameworks.sh"
   },
   "author": "Voxeet",
   "license": "GPL-3.0",
-  "engines": {
-    "cordovaDependencies": {
-      "3.0.0": {
-        "cordova": ">100"
-      }
-    }
-  },
+  "engines": { "cordova": ">=7.0.0"},
   "devDependencies": {
     "eslint": "^3.19.0",
     "eslint-config-semistandard": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "test": "npm run eslint",
     "eslint": "node node_modules/eslint/bin/eslint www && node node_modules/eslint/bin/eslint src && node node_modules/eslint/bin/eslint tests",
-    "buildios": "bash build_ios_frameworks.sh"
+    "postinstall": "bash build_ios_frameworks.sh"
   },
   "author": "Voxeet",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,7 @@
   "scripts": {
     "test": "npm run eslint",
     "eslint": "node node_modules/eslint/bin/eslint www && node node_modules/eslint/bin/eslint src && node node_modules/eslint/bin/eslint tests",
-<<<<<<< HEAD
     "buildios": "bash build_ios_frameworks.sh"
-=======
-    "postinstall": "bash build_ios_frameworks.sh"
->>>>>>> f0c86c142eac1440f12bf9beb195498d42d494ba
   },
   "author": "Voxeet",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "test": "npm run eslint",
     "eslint": "node node_modules/eslint/bin/eslint www && node node_modules/eslint/bin/eslint src && node node_modules/eslint/bin/eslint tests",
-    "postinstall": "bash build_ios_frameworks.sh"
+    "build:ios": "bash build_ios_frameworks.sh"
   },
   "author": "Voxeet",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "test": "npm run eslint",
     "eslint": "node node_modules/eslint/bin/eslint www && node node_modules/eslint/bin/eslint src && node node_modules/eslint/bin/eslint tests",
-    "postinstall": "bash build_ios_frameworks.sh"
+    "buildios": "bash build_ios_frameworks.sh"
   },
   "author": "Voxeet",
   "license": "GPL-3.0",

--- a/plugin.xml
+++ b/plugin.xml
@@ -78,6 +78,8 @@
 
     <!-- ios -->
     <platform name="ios">
+        <hook type="after_add" src="build_ios_frameworks.sh">
+        <hook type="after_platform" src="build_ios_frameworks.sh">
         <config-file target="config.xml" parent="/*">
             <feature name="Voxeet">
                 <param name="ios-package" value="CDVVoxeet" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -78,8 +78,8 @@
 
     <!-- ios -->
     <platform name="ios">
-        <hook type="after_add" src="build_ios_frameworks.sh"/>
-        <hook type="after_platform" src="build_ios_frameworks.sh"/>
+        <hook type="before_add" src="build_ios_frameworks.sh"/>
+        <hook type="before_platform" src="build_ios_frameworks.sh"/>
         <config-file target="config.xml" parent="/*">
             <feature name="Voxeet">
                 <param name="ios-package" value="CDVVoxeet" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -78,8 +78,8 @@
 
     <!-- ios -->
     <platform name="ios">
-        <hook type="after_add" src="build_ios_frameworks.sh">
-        <hook type="after_platform" src="build_ios_frameworks.sh">
+        <hook type="after_add" src="build_ios_frameworks.sh"/>
+        <hook type="after_platform" src="build_ios_frameworks.sh"/>
         <config-file target="config.xml" parent="/*">
             <feature name="Voxeet">
                 <param name="ios-package" value="CDVVoxeet" />


### PR DESCRIPTION
This allows setting an env variable (README updated) to disable the ios build. This can be useful for CI as well as for non ios supporting machines (namely linux & windows). 
Alternatively, the script can be removed from postinstall and be triggered intentionally when needed. 